### PR TITLE
Restart streams after Reddit error

### DIFF
--- a/newpost.py
+++ b/newpost.py
@@ -105,6 +105,6 @@ while True:
         sys.exit(0)
     except Exception as e:
         print('Error:', e)
-        time.sleep(5)
+        time.sleep(30)
 
 

--- a/newpost.py
+++ b/newpost.py
@@ -68,6 +68,13 @@ def notify_telegram(subreddit, title, url):
     requests.post("https://api.telegram.org/bot{}/sendMessage".format(config['telegram']['token']),
                   data=payload)
 
+def start_streams():
+    modqueue_stream = (r.subreddit('mod').mod.stream.modqueue(pause_after=-1)
+                       if config['modqueue'] else [])
+    submission_stream = (r.subreddit(subreddits).stream.submissions(pause_after=-1)
+                         if config['new_posts'] else [])
+    return modqueue_stream, submission_stream
+
 with open(CONFIG_FILE) as config_file:
     config = json.load(config_file)
 
@@ -81,10 +88,7 @@ r = praw.Reddit(
 
 first = True
 subreddits = '+'.join(config['subreddits'])
-modqueue_stream = (r.subreddit('mod').mod.stream.modqueue(pause_after=-1)
-                   if config['modqueue'] else [])
-submission_stream = (r.subreddit(subreddits).stream.submissions(pause_after=-1)
-                     if config['new_posts'] else [])
+(modqueue_stream, submission_stream) = start_streams()
 
 while True:
     try:
@@ -106,5 +110,5 @@ while True:
     except Exception as e:
         print('Error:', e)
         time.sleep(30)
-
+        (modqueue_stream, submission_stream) = start_streams()
 


### PR DESCRIPTION
I found that after 2-3 days the stream would stop reading new posts.
Some digging revealed that after Reddit was unavailable for a bit, PRAW would give up and the streams would not read any new posts.

I've added some delay after an exception (most likely caused by a 503 error on Reddit's side), after which the streams are restarted.